### PR TITLE
Fix user image update triggering on first login

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -3,7 +3,7 @@
 const { encode } = require('../utils'),
   encrypt = require('../services/encrypt');
 let db = require('../services/storage'),
-  bus;
+  bus = require('../services/bus');
 
 /**
  * Adds an user into the db and publishes the action to the bus

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const _isEmpty = require('lodash/isEmpty'),
   { AUTH_LEVELS } = require('./constants'),
   { withAuthLevel } = require('./services/auth'),
   { setDb } = require('./services/storage'),
-  { setBus } = require('./controllers/users');
+  { setBus } = require('./services/bus');
 
 /**
  * determine if a route is protected

--- a/services/bus.js
+++ b/services/bus.js
@@ -1,0 +1,15 @@
+'use strict';
+
+let bus; // Redis bus passed from Amphora. Assigned value at initialization
+
+/**
+ * Retrieves an item from the database.
+ * @param {string} eventName
+ * @param {Object} data
+ */
+function publish(eventName, data) {
+  bus.publish(eventName, data);
+}
+
+module.exports.publish = publish;
+module.exports.setBus = redisBus => bus = redisBus;

--- a/utils.js
+++ b/utils.js
@@ -13,7 +13,8 @@ const _get = require('lodash/get'),
   references = require('./services/references'),
   { isValidPassword } = require('./services/encrypt');
 
-let db = require('./services/storage');
+let db = require('./services/storage'),
+  bus = require('./services/bus');
 
 /**
  * encode username and provider to base64
@@ -97,6 +98,9 @@ function verify(properties) {
                 return done(null, false, { message: 'Invalid Password' });
               }
 
+              data._ref = uid;
+
+              bus.publish('saveUser', { key: uid, value: data }); // Tell elastic about any update changes to maintain data consistency
               return done(null, data);
             })
             .catch(e => done(e));
@@ -254,5 +258,6 @@ module.exports.getUri = getUri;
 
 // For testing purposes
 module.exports.setDb = mock => db = mock;
+module.exports.setBus = mock => bus = mock;
 module.exports.removeQueryString = removeQueryString;
 module.exports.removeExtension = removeExtension;

--- a/utils.test.js
+++ b/utils.test.js
@@ -8,12 +8,16 @@ const _startCase = require('lodash/startCase'),
   storage = require('./test/fixtures/mocks/storage');
 
 describe(_startCase(filename), function () {
-  let fakeDb;
+  let fakeDb, fakeBus;
 
   beforeEach(function () {
     fakeDb = storage();
+    fakeBus = {
+      publish: jest.fn()
+    };
 
     lib.setDb(fakeDb);
+    lib.setBus(fakeBus);
   });
 
   describe('compileTemplate', function () {


### PR DESCRIPTION
The user's associated image that it's used in Clay was not getting updated on the first login in Elastic. It only had the updated information in Postgres, which was causing a disparity in the Elastic data. 

(This is needed also to normalize the user's data) 

[Issue](https://app.zenhub.com/workspaces/clay-repos-596524da4a8a0769f2f03175/issues/clay/amphora-search/38)