### PR TITLE
Extends isProtectedRoute to allow HEAD requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,16 @@ const _isEmpty = require('lodash/isEmpty'),
 
 /**
  * determine if a route is protected
- * protected routes are ?edit=true and any method other than GET
+ * protected routes are ?edit=true and any method other than GET or HEAD
  * @param {object} req
  * @returns {boolean}
  */
 function isProtectedRoute(req) {
-  return !!req.query.edit || !_includes(req.originalUrl, '/_auth') && req.method !== 'GET';
+  return (
+    !!req.query.edit
+    || !_includes(req.originalUrl, '/_auth')
+    && !_includes(['GET', 'HEAD'], req.method)
+  );
 }
 
 /**

--- a/index.test.js
+++ b/index.test.js
@@ -30,6 +30,10 @@ describe(_startCase(filename), function () {
     it('is false if GET to api (or non-edit page)', function () {
       expect(fn({ query: {}, method: 'GET' })).toEqual(false);
     });
+
+    it('is false if HEAD to api (or non-edit page)', function () {
+      expect(fn({ query: {}, method: 'HEAD' })).toEqual(false);
+    });
   });
 
   describe('isAuthenticated', function () {


### PR DESCRIPTION
This commit is to address a problem that has been perplexing me for months. Whenever I try to make a HEAD request to a clay page I get a 302 redirect to `/_auth/login` instead of getting response headers from the page.

The consequence of this behavior is that one is forced to render and download the full page contents, when they may only be interested in the Content-Length, status code, or other bits of information.