### PR TITLE
adds 'Secure: true' for clay-session cookie

### DIFF
--- a/services/session-store.js
+++ b/services/session-store.js
@@ -33,6 +33,7 @@ function createSessionStore(store = {}) {
     name: 'clay-session',
     cookie: {
       maxAge: 1000 * 60 * 60 * 24 * 7, // 1 week
+      secure: true
     },
     store: redisStore,
   });


### PR DESCRIPTION
Browsers are throwing warnings that the `clay-session` cookie will be rejected due to the presence of `SameSite: "None"` without `Secure: true`. This commit adds the `Secure: true` attribute to the cookie.