### PR TITLE
renders local login form if and only if you're using it

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,12 +73,13 @@ function protectRoutes(site) {
 /**
  * middleware to show login page
  * @param {object} site
- * @param {array} currentProviders
+ * @param {array} providers
  * @returns {function}
  */
-function onLogin(site, currentProviders) {
+function onLogin(site, providers) {
   return function (req, res) {
     const template = compileLoginPage(),
+      currentProviders = getProviders(providers, site),
       authUrl = getAuthUrl(site),
       flash = req.flash();
 
@@ -102,7 +103,8 @@ function onLogin(site, currentProviders) {
         currentProviders: currentProviders,
         user: req.user,
         logoutLink: `${authUrl}/logout`,
-        localAuthPath: `${authUrl}/local`
+        localAuthPath: `${authUrl}/local`,
+        useLocalAuth: providers.includes('local')
       }));
     }
   };
@@ -185,7 +187,7 @@ function init({ router, providers, store, site, storage, bus }) {
   // add authorization routes
   // note: these (and the provider routes) are added here,
   // rather than as route controllers in lib/routes/
-  router.get('/_auth/login', onLogin(site, currentProviders));
+  router.get('/_auth/login', onLogin(site, providers));
   router.get('/_auth/logout', onLogout(site));
   strategyService.addAuthRoutes(providers, router, site); // allow mocking this in tests
 

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -193,13 +193,14 @@
                 </a>
             {{/each}}
           </div>
-          <p class="separator">or</p>
         {{/if}}
+        {{#if useLocalAuth}}
         <form class="login-form" action="{{localAuthPath}}" method="post">
           <input id="username" name="username" type="text" placeholder="Username" />
           <input id="password" name="password" type="password" placeholder="Password" />
           <button type="submit">Login</button>
         </form>
+        {{/if}}
       {{/if}}
     </div>
   </div>


### PR DESCRIPTION
### Description of Changes
Updates the login view to render the local login form only if it's one of the auth providers.

### Steps to Test
1. Local setup:
- In amphora-auth: `npm i && npm link`
- In amphora: `npm i && npm link && npm link amphora-auth`
- In your app: `npm link amphora`

2. To test, modify your amphora instantation:
```javascript
const providers = ['google', 'local'];
amphora({
      app,
      renderers,
      providers,
      sessionStore,
      storage,
      eventBus,
      plugins: [amphoraSearchPlugin, amphoraSchedule],
      bootstrap: bootstrapOnStart && isBootstrapProcess
    });
```

2. Add 'local' to this list and verify that you see the login form. Remove it and verify that you don't.