### PR TITLE
Update to allow for a PREVIOUS_CLAY_ACCESS_KEY

### DIFF
--- a/strategies/key.js
+++ b/strategies/key.js
@@ -10,7 +10,8 @@ const passport = require('passport'),
  * @param {function} done
  */
 function apiCallback(apikey, done) {
-  if (apikey === process.env.CLAY_ACCESS_KEY) {
+  if (apikey === process.env.CLAY_ACCESS_KEY ||
+      apikey === process.env.PREVIOUS_CLAY_ACCESS_KEY) {
     // If we're using an API Key then we're assuming the user is
     // has admin privileges by defining the auth level in the next line
     done(null, { provider: 'apikey', auth: 'admin' });

--- a/strategies/key.test.js
+++ b/strategies/key.test.js
@@ -22,15 +22,33 @@ describe(_startCase(filename), function () {
       });
     });
 
-    it('disallows api key that does not match CLAY_ACCESS_KEY', function (done) {
+    it('allows an api key that matches PREVIOUS_CLAY_ACCESS_KEY', function (done) {
       const oldKey = process.env.CLAY_ACCESS_KEY;
+      const olderKey = process.env.PREVIOUS_CLAY_ACCESS_KEY;
 
       process.env.CLAY_ACCESS_KEY = '123';
+      process.env.PREVIOUS_CLAY_ACCESS_KEY = '789';
+      fn('789', function (err, data) {
+        expect(err).toEqual(null);
+        expect(data).toEqual({ provider: 'apikey', auth: 'admin' });
+        process.env.CLAY_ACCESS_KEY = oldKey;
+        process.env.PREVIOUS_CLAY_ACCESS_KEY = olderKey;
+        done();
+      });
+    });
+
+    it('disallows api key that does not match CLAY_ACCESS_KEY or PREVIOUS_CLAY_ACCESS_KEY', function (done) {
+      const oldKey = process.env.CLAY_ACCESS_KEY;
+      const olderKey = process.env.PREVIOUS_CLAY_ACCESS_KEY;
+
+      process.env.CLAY_ACCESS_KEY = '123';
+      process.env.PREVIOUS_CLAY_ACCESS_KEY = '789';
       fn('456', function (err, data, status) {
         expect(err).toEqual(null);
         expect(data).toEqual(false);
         expect(status.message).toEqual('Unknown apikey: 456');
         process.env.CLAY_ACCESS_KEY = oldKey;
+        process.env.PREVIOUS_CLAY_ACCESS_KEY = olderKey;
         done();
       });
     });


### PR DESCRIPTION
Fixes #37 

This will allow us to have servers using both the old and new access keys as we are rotating keys.